### PR TITLE
Fixed some nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ This time you should get an HTTP `200` response, meaning that the request was su
 > **INFO:** in this case, the `CiliumNetworkPolicy` not only allows the traffic to `www.roche.com` but also instead of sending it to the linux networking stack, redirects it to the envoy listener defined in the `CiliumEnvoyConfig`, and there envoy routes the traffic to the proxy running on `kubecon-proxy-demo` EC2 instance using `HTTP CONNECT` method.
 
 Move back to the terminal where you are monitoring the logs of the HTTP proxy.
-You should see a log message for the request that the proxy received and routed to `www.roche.com`, similar to this:
+You should see a log message for the request that the proxy received and routed to the CDN IP behind `www.roche.com`, similar to this:
 
 ```logs
-{"time_unix":1707585823, "proxy":{"type:":"PROXY", "port":3128}, "error":{"code":"00000"}, "auth":{"user":"-"}, "client":{"ip":"3.123.33.107", "port":38522}, "server":{"ip":"142.250.185.228", "port":443}, "bytes":{"sent":844, "received":5871}, "request":{"hostname":"142.250.185.228"}, "message":"CONNECT 142.250.185.228:443 HTTP/1.1"}
+{"time_unix":1707585823, "proxy":{"type:":"PROXY", "port":3128}, "error":{"code":"00000"}, "auth":{"user":"-"}, "client":{"ip":"3.123.33.107", "port":38522}, "server":{"ip":"xxx.xxx.xxx.xxx", "port":443}, "bytes":{"sent":844, "received":5871}, "request":{"hostname":"xxx.xxx.xxx.xxx"}, "message":"CONNECT xxx.xxx.xxx.xxx:443 HTTP/1.1"}
 ```
 
 ## Clean up

--- a/kubernetes/cnp_proxy.yaml
+++ b/kubernetes/cnp_proxy.yaml
@@ -19,8 +19,6 @@ spec:
               kind: "CiliumEnvoyConfig"
               name: "proxy-envoy"
             name: "proxy-listener"
-    - toEndpoints:
-        - {}
     - toEntities:
         - cluster
     - toEndpoints:
@@ -30,7 +28,7 @@ spec:
       toPorts:
         - ports:
             - port: "53"
-              protocol: UDP
+              protocol: ANY
           rules:
             dns:
               - matchPattern: "*"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -16,6 +16,6 @@ terraform {
 }
 
 provider "aws" {
-  # add here provider configuration if needed
-
+  # add/change provider configuration here, if needed
+  region = "eu-central-1"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "env_name" {
   default     = "demo"
 }
 
+variable "cidr" {
+  description = "The CIDR to be used for the VPC."
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
 locals {
   machine_kind_name  = "kubecon-kind-${var.env_name}"
   machine_proxy_name = "kubecon-proxy-${var.env_name}"
@@ -13,7 +19,7 @@ locals {
 
 # get my poublic ip to configure EC2 SG (incoming) via SSH
 data "http" "myip" {
-  url = "http://ifconfig.me"
+  url = "http://checkip.amazonaws.com"
 }
 
 # AMI

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -1,13 +1,20 @@
+// List of availability zones for the chosen region.
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.19.0"
 
-  name = local.vpc_name
-  cidr = "10.0.0.0/16"
-
-  azs             = ["eu-central-1a"]
+  name            = local.vpc_name
+  cidr            = var.cidr
+  azs             = data.aws_availability_zones.available.names
   private_subnets = []
-  public_subnets  = ["10.0.101.0/24"]
+  public_subnets = [
+    for i, v in data.aws_availability_zones.available.names :
+    cidrsubnet(var.cidr, 8, 100 + i)
+  ]
 
   enable_nat_gateway = false
   enable_vpn_gateway = false


### PR DESCRIPTION
* README.md: Added hint regarding the destination IP seen in the forward proxy log
* cnp_proxy.yaml:
  * Removed toEntities for NS-internal communication as it's already allowed to communicate to the Cilium entity 'cluster'.
  * Also allowed TCP-based DNS queries to core-dns
* providers.tf: Added region to make it more clear for users where this will be deployed, in case they don't change anything.
* variables.tf:
  * Added var for the VPC CIDR configuration
  * Switched from ifconfig.me to checkip.amazonaws.com as the first one returned the IPv6 address in case dual-stack is enabled on the client's network. Hence, TF would have failed to apply the AWS SG ingress/egress rules.
* vpc.tf: Changed the VPC public_subnets selection to a dynamic logic